### PR TITLE
Update sched.h - Potential typo

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -779,7 +779,8 @@ struct task_struct {
 	int				wake_cpu;
 #endif
 	int				on_rq;
-#ifdef CONFIG_MTK_SCHED_BOOST
+/*#ifdef CONFIG_MTK_SCHED_BOOST*/
+#ifdef CONFIG_MTK_TASK_TURBO
 	int				cpu_prefer;
 #endif
 


### PR DESCRIPTION
In line 783, when compiling the kernel with MTK Task Turbo, task_turbo.c may not compile correctly as the variable that is used may be hidden as it requires CONFIG_MTK_SCHED_BOOST to be y. In selene_defconfig, I searched for CONFIG_MTK_SCHED_BOOST and there was no such option so I think "#ifdef CONFIG_MTK_SCHED_BOOST" might be a typo. Therefore, MTK Task Turbo might compile with the kernel successfully.